### PR TITLE
Phantomjs fixture

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -18,3 +18,9 @@ txfixtures.service
 
 .. automodule:: txfixtures.service
    :members:
+
+txfixtures.phantomjs
+--------------------
+
+.. automodule:: txfixtures.phantomjs
+   :members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,6 +21,7 @@ Contents:
 
    reactor
    service
+   phantomjs
    api
 
 Indices and tables

--- a/doc/phantomjs.rst
+++ b/doc/phantomjs.rst
@@ -1,0 +1,40 @@
+Setup a phantomjs Selenium driver
+=================================
+
+The :class:`~txfixtures.phantomjs.PhantomJS` fixture starts a
+phantomjs_ service in the background and exposes it via its
+`webdriver` attribute, which can then be used by test cases for
+Selenium_-based assertions:
+
+.. doctest::
+
+   >>> from fixtures import FakeLogger
+   >>> from testtools import TestCase
+   >>> from txfixtures import Reactor, Service, PhantomJS
+
+   >>> TWIST_COMMAND = "twistd -n web".split(" ")
+
+   >>> class HTTPServerTest(TestCase):
+   ...
+   ...     def setUp(self):
+   ...         super().setUp()
+   ...         self.logger = self.useFixture(FakeLogger())
+   ...         self.useFixture(Reactor())
+   ...
+   ...         # Create a sample web server
+   ...         self.service = Service(TWIST_COMMAND)
+   ...         self.service.expectPort(8080)
+   ...         self.useFixture(self.service)
+   ...
+   ...         self.phantomjs = self.useFixture(PhantomJS())
+   ...
+   ...     def test_home_page(self):
+   ...         self.phantomjs.webdriver.get("http://localhost:8080")
+   ...         self.assertEqual("Twisted Web Demo", self.phantomjs.webdriver.title)
+
+   >>> test = HTTPServerTest(methodName="test_home_page")
+   >>> test.run().wasSuccessful()
+   True
+
+.. _phantomjs: http://phantomjs.org
+.. _Selenium: http://selenium-python.readthedocs.io/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+extras
 fixtures
 testtools
 twisted

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,8 @@ test =
     systemfixtures
 doc =
     sphinx
+phantomjs =
+    selenium
 
 [bdist_wheel]
 universal = 1

--- a/tests/test_phantomjs.py
+++ b/tests/test_phantomjs.py
@@ -1,0 +1,29 @@
+from testtools import TestCase
+
+from fixtures import FakeLogger
+
+from txfixtures.reactor import Reactor
+from txfixtures.service import Service
+from txfixtures.phantomjs import PhantomJS
+
+
+class PhantomJSIntegrationTest(TestCase):
+
+    def setUp(self):
+        super(PhantomJSIntegrationTest, self).setUp()
+        self.logger = self.useFixture(FakeLogger())
+        self.useFixture(Reactor())
+
+        # Setup a local web server to test the WebDriver
+        server = Service(["twist", "web"], timeout=5)
+        server.expectOutput("Starting reactor...")
+        server.expectPort(8080)
+        self.useFixture(server)
+
+        self.fixture = PhantomJS(timeout=5)
+
+    def test_webdriver(self):
+        """After setUp is run, the service is fully ready."""
+        self.useFixture(self.fixture)
+        self.fixture.webdriver.get("http://localhost:8080")
+        self.assertEqual("Twisted Web Demo", self.fixture.webdriver.title)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2,8 +2,6 @@ import os
 import signal
 import socket
 
-from six import b
-
 from testtools import TestCase
 from testtools.twistedsupport import AsynchronousDeferredRunTest
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,10 @@ skipsdist = True
 [testenv]
 usedevelop = True
 install_command = pip install -U {opts} {packages}
-deps = .[test]
-whitelist_externals = make
+deps = .[test,phantomjs]
+whitelist_externals =
+    make
+    phantomjs
 setenv =
     TWISTD_SCRIPT={envbindir}/twistd
     COVERAGE=coverage
@@ -19,6 +21,6 @@ commands =
 
 [testenv:doc]
 basepython = python3.5
-deps = .[doc,test]
+deps = .[doc,test,phantomjs]
 commands =
     make check-doc

--- a/txfixtures/__init__.py
+++ b/txfixtures/__init__.py
@@ -1,13 +1,20 @@
 from pbr.version import VersionInfo
 
+from extras import try_import
+
 from .reactor import (
     Reactor,
 )
 from .service import Service
 
+# Since the PhantomJS fixure requires the Selenium Python package, we make
+# the import fail gracefully if it's not installed.
+PhantomJS = try_import("txfixtures.phantomjs.PhantomJS")
+
 __all__ = [
     "Reactor",
     "Service",
+    "PhantomJS",
 ]
 
 _v = VersionInfo("txfixtures").semantic_version()

--- a/txfixtures/_twisted/tests/test_threading.py
+++ b/txfixtures/_twisted/tests/test_threading.py
@@ -3,7 +3,6 @@ from six import b
 from testtools import TestCase
 
 from twisted.internet import reactor
-from twisted.internet.utils import getProcessOutput
 from twisted.internet.defer import (
     Deferred,
     succeed,

--- a/txfixtures/phantomjs.py
+++ b/txfixtures/phantomjs.py
@@ -1,0 +1,44 @@
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.common import utils
+from selenium.webdriver.remote import webdriver
+
+from fixtures import TempDir
+
+from txfixtures.service import Service
+
+FORMAT = (
+    "\[{levelname} +- +{Y}-{m}-{d}T{H}:{M}:{S}\.{msecs}Z\] {name} - {message}")
+
+
+class PhantomJS(Service):
+    """Start and stop a `phantomjs` process in the background. """
+
+    def __init__(self, phantomjs="phantomjs", args=(), **kwargs):
+        command = [phantomjs] + list(args)
+        super(PhantomJS, self).__init__(command, **kwargs)
+
+        #: Desired capabilities that will be passed to the webdriver.
+        self.desiredCapabilities = DesiredCapabilities.PHANTOMJS
+
+        #: A WebDriver instance pointing to the phantomjs process spawned
+        #: by this fixture.
+        self.webdriver = None
+
+        self.expectOutput("running on port")
+        self.setOutputFormat(FORMAT)
+
+    def _setUp(self):
+        self.expectPort(utils.free_port())
+        self._cookies = self.useFixture(TempDir()).join("phantomjs.cookies")
+        super(PhantomJS, self)._setUp()
+        url = "http://localhost:%d/wd/hub" % self.protocol.expectedPort
+        self.webdriver = webdriver.WebDriver(
+            command_executor=url,
+            desired_capabilities=self.desiredCapabilities)
+
+    @property
+    def _args(self):
+        return self.command[:] + [
+            "--webdriver=%d" % self.protocol.expectedPort,
+            "--cookies-file=%s" % self._cookies,
+        ]

--- a/txfixtures/tests/test_phantomjs.py
+++ b/txfixtures/tests/test_phantomjs.py
@@ -1,0 +1,53 @@
+import os
+
+from testtools import TestCase
+from testtools.matchers import (
+    StartsWith,
+    DirExists,
+)
+
+from selenium.webdriver.common import utils
+from selenium.webdriver.remote import webdriver
+
+from fixtures import FakeLogger
+
+from txfixtures._twisted.testing import ThreadedMemoryReactorClock
+
+from txfixtures.phantomjs import PhantomJS
+
+OUT = (
+    b"[INFO  - 2016-11-17T09:01:38.591Z] GhostDriver - "
+    b"Main - running on port 666\n"
+)
+
+
+class PhantomJSTest(TestCase):
+
+    def setUp(self):
+        super(PhantomJSTest, self).setUp()
+        self.logger = self.useFixture(FakeLogger())
+        self.reactor = ThreadedMemoryReactorClock()
+        self.fixture = PhantomJS(reactor=self.reactor)
+
+    def test_setup(self):
+        """
+        The fixture passes port and cookies paths as extra argument, and
+        configure the output format to match phantomjs' one.
+        """
+        self.reactor.process.data = OUT
+
+        class FakeWebDriver(object):
+
+            def __init__(self, **kwargs):
+                pass
+
+        self.patch(utils, "free_port", lambda: 666)
+        self.patch(webdriver, "WebDriver", FakeWebDriver)
+
+        self.fixture.setUp()
+        executable, arg1, arg2 = self.reactor.process.args
+        self.assertEqual("phantomjs", executable)
+        self.assertEqual("--webdriver=666", arg1)
+        self.assertThat(arg2, StartsWith("--cookies-file="))
+        self.assertThat(os.path.dirname(arg2.split("=")[1]), DirExists())
+        self.assertIn("running on port 666", self.logger.output)


### PR DESCRIPTION
Add a txfixtures.PhantomJS fixture for spawning a background phantomjs process. The dependency on Selenium is optional (if it's not present imports won't break, but the fixture won't be available).