### PR TITLE
Don't use set_wakeup_fd to wake up the reactor on SIGCHLD

### DIFF
--- a/tests/test_phantomjs.py
+++ b/tests/test_phantomjs.py
@@ -26,7 +26,7 @@ class PhantomJSIntegrationTest(TestCase):
         server.expectPort(8080)
         self.useFixture(server)
 
-        self.fixture = PhantomJS(timeout=5)
+        self.fixture = PhantomJS(timeout=10)
 
     @skipIf(not hasTwist, "twist executable not available")
     def test_webdriver(self):

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -133,6 +133,9 @@ class ReactorPatcher(MonkeyPatcher):
         #
         # Here we check if the function argument matches the function that
         # we want to timeout.
+        if not args:
+            return
+
         if args[1] == self.callFromThreadTimeout:
             logging.info("Trigger callFromThread timeout")
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -52,6 +52,7 @@ class ServiceIntegrationTest(TestCase):
     def test_unknown_command(self):
         """If an unknown command is given, setUp raises an error."""
         self.fixture.command = [b"/foobar"]
+        self.fixture.protocol.minUptime = 2.5
         error = self.assertRaises(MultipleExceptions, self.fixture.setUp)
         self.assertIsInstance(error.args[0][1], ProcessTerminated)
         self.assertIn("No such file or directory", self.logger.output)
@@ -169,6 +170,7 @@ class ServiceProtocolIntegrationTest(TestCase):
                 "The 'ready' deferred did not errback, while we were expecting"
                 "an error, due to the process not staying up for at least 0.1"
                 "seconds")
+        yield self.protocol.terminated
 
     @inlineCallbacks
     def test_no_expected_output_exit(self):
@@ -185,6 +187,7 @@ class ServiceProtocolIntegrationTest(TestCase):
             self.assertEqual(0, error.exitCode)
         else:
             self.fail("The 'ready' deferred did not errback")
+        yield self.protocol.terminated
 
     @inlineCallbacks
     def test_no_expected_output_timeout(self):
@@ -245,3 +248,4 @@ class ServiceProtocolIntegrationTest(TestCase):
             self.assertEqual(0, error.exitCode)
         else:
             self.fail("The 'ready' deferred did not errback")
+        yield self.protocol.terminated

--- a/txfixtures/service.py
+++ b/txfixtures/service.py
@@ -276,7 +276,12 @@ class ServiceProtocol(ProcessProtocol):
     def processEnded(self, reason):
         # Called when the process has been reaped.
         logging.info("Service process reaped")
-        self.terminated.callback(None)
+
+        # Fire the terminated Deferred asynchronously in the next event loop
+        # iteration, since our caller (twisted/internet/process.py) needs
+        # to perform some cleanup *before* we unblock our own code that is
+        # waiting for self.terminated.
+        self.reactor.callLater(0, self.terminated.callback, None)
 
     def _minUptimeElapsed(self):
         """

--- a/txfixtures/tests/test_reactor.py
+++ b/txfixtures/tests/test_reactor.py
@@ -5,11 +5,13 @@ from fixtures import FakeLogger
 from systemfixtures import FakeThreads
 
 from twisted.internet.defer import succeed
-from twisted.internet.posixbase import _SIGCHLDWaker
 
 from txfixtures._twisted.testing import ThreadedMemoryReactorClock
 
-from txfixtures.reactor import Reactor
+from txfixtures.reactor import (
+    Reactor,
+    _ChildWaker,
+)
 
 
 class ReactorTest(TestCase):
@@ -27,8 +29,7 @@ class ReactorTest(TestCase):
         """
         self.fixture.setUp()
         [reader] = list(self.reactor.readers)
-        self.assertIsInstance(reader, _SIGCHLDWaker)
-        self.assertTrue(reader.installed)
+        self.assertIsInstance(reader, _ChildWaker)
 
     def test_call(self):
         """The call() method is a convenience around blockingFromThread."""

--- a/txfixtures/tests/test_service.py
+++ b/txfixtures/tests/test_service.py
@@ -142,6 +142,7 @@ class ServiceTest(TestCase):
         """
         self.fixture.setUp()
         self.reactor.process.processEnded(Failure(Exception("boom")))
+        self.reactor.advance(0)
         error = self.assertRaises(RuntimeError, self.fixture.reset)
         self.assertEqual("Service died", str(error))
 
@@ -350,6 +351,7 @@ class ServiceProtocolTest(TestCase):
         self.protocol.makeConnection(self.process)
         self.reactor.advance(self.protocol.minUptime)
         self.protocol.transport.processEnded(0)
+        self.reactor.advance(0)
         self.assertThat(self.protocol.terminated, succeeded(Is(None)))
 
 


### PR DESCRIPTION
Twisted's default mechanisim to wake up the main loop upon SIGCHLD
relies on signal.set_wakeup_fd to write a zero-length string to the
_SIGCHLDWaker's read pipe. However that seems to be thread unsafe,
so we use callFromThread to implement the same behavior by hand.