### PR TITLE
Fix a couple of pidfile-handling races

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifier =
 [extras]
 test =
     coverage
-    retrying
     systemfixtures>=0.6.2
 doc =
     sphinx

--- a/txfixtures/osutils.py
+++ b/txfixtures/osutils.py
@@ -30,11 +30,12 @@ def _kill_may_race(pid, signal_number):
 
 def get_pid_from_file(pidfile_path):
     """Retrieve the PID from the given file, if it exists, None otherwise."""
-    if not os.path.exists(pidfile_path):
+    # Get the pid, ignoring failures due to the pidfile not existing.
+    try:
+        with open(pidfile_path, 'r') as fd:
+            pid = fd.read().split()[0]
+    except IOError:
         return None
-    # Get the pid.
-    with open(pidfile_path, 'r') as fd:
-        pid = fd.read().split()[0]
     try:
         pid = int(pid)
     except ValueError:

--- a/txfixtures/tachandler.py
+++ b/txfixtures/tachandler.py
@@ -105,19 +105,23 @@ class TacTestFixture(Fixture):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             )
-        self.addCleanup(self.killTac)
-        stdout = until_no_eintr(10, self._proc.stdout.read)
-        if stdout:
-            raise TacException('Error running %s: unclean stdout/err: %s'
-                               % (args, stdout))
-        rv = self._proc.wait()
-        # twistd will normally fork off into the background with the
-        # originally-spawned process exiting 0.
-        if rv != 0:
-            raise TacException('Error %d running %s' % (rv, args))
+        try:
+            self.addCleanup(self.killTac)
+            stdout = until_no_eintr(10, self._proc.stdout.read)
+            if stdout:
+                raise TacException('Error running %s: unclean stdout/err: %s'
+                                   % (args, stdout))
+            rv = self._proc.wait()
+            # twistd will normally fork off into the background with the
+            # originally-spawned process exiting 0.
+            if rv != 0:
+                raise TacException('Error %d running %s' % (rv, args))
 
-        self.addDetail(self.logfile, content_from_file(self.logfile))
-        self._waitForDaemonStartup()
+            self.addDetail(self.logfile, content_from_file(self.logfile))
+            self._waitForDaemonStartup()
+        except Exception:
+            self.cleanUp()
+            raise
 
     def _hasDaemonStarted(self):
         """Has the daemon started?

--- a/txfixtures/tachandler.py
+++ b/txfixtures/tachandler.py
@@ -105,8 +105,8 @@ class TacTestFixture(Fixture):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             )
+        self.addCleanup(self.killTac)
         try:
-            self.addCleanup(self.killTac)
             stdout = until_no_eintr(10, self._proc.stdout.read)
             if stdout:
                 raise TacException('Error running %s: unclean stdout/err: %s'


### PR DESCRIPTION
If `twistd` happened to be preempted between writing exception details to its status pipe and removing the pidfile (the only way I know to exercise this is to temporarily insert `time.sleep` in the middle of `twisted.scripts._twistd_unix.UnixApplicationRunner.postApplication`), then there were a couple of ways in which `TacTestFixture` could go wrong: one was a simple race due to look-before-you-leap, and one was a more subtle failure to adhere to the fixtures contract.  Full details are in the individual commit messages.