### PR TITLE
Fix ServiceProtocol integration test failures

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -133,9 +133,6 @@ class ServiceProtocolIntegrationTest(TestCase):
         self.protocol.expectedPort = self.script.port
         self.process = reactor.spawnProcess(self.protocol, self.script.path)
         yield self.protocol.ready
-        sock = socket.socket()
-        sock.connect(("localhost", self.script.port))
-        self.addCleanup(sock.close)
         self.assertIn("Service opened port", self.logger.output)
 
     @inlineCallbacks
@@ -150,9 +147,6 @@ class ServiceProtocolIntegrationTest(TestCase):
         self.protocol.expectedPort = self.script.port
         self.process = reactor.spawnProcess(self.protocol, self.script.path)
         yield self.protocol.ready
-        sock = socket.socket()
-        sock.connect(("localhost", self.script.port))
-        self.addCleanup(sock.close)
         self.assertIn("Service port probe failed", self.logger.output)
         self.assertIn("Service opened port", self.logger.output)
 


### PR DESCRIPTION
test_ready_with_expected_port and test_ready_with_expected_port_retry
were failing to connect to the test service with "Connection refused".
However, ServiceProtocol itself already does a test connection when
`expectedPort` is set; this is already tested by looking for "Service
opened port" in the logger output, and I confirmed this with strace; the
second connection simply fails because FakeExecutable isn't particularly
robust, I think specifically because its listening socket buffer is
full.

Since the second connection is entirely superfluous, we can safely just
remove it from these two tests.