### PR TITLE
Make two_stage_kill more robust

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifier =
 [extras]
 test =
     coverage
+    mock; python_version<"3"
     systemfixtures>=0.6.2
 doc =
     sphinx

--- a/txfixtures/tests/test_osutils.py
+++ b/txfixtures/tests/test_osutils.py
@@ -1,0 +1,91 @@
+# Copyright 2009-2020 Canonical Ltd.  This software is licensed under the
+# GNU General Public License version 3.
+
+import errno
+import os
+import signal
+
+from fixtures import MockPatch
+from testtools import TestCase
+
+from txfixtures.osutils import (
+    process_exists,
+    two_stage_kill,
+    )
+
+
+class TestProcessExists(TestCase):
+
+    def test_with_process_running(self):
+        pid = os.getpid()
+        self.assertTrue(process_exists(pid))
+
+    def test_with_process_not_running(self):
+        exception = OSError()
+        exception.errno = errno.ESRCH
+        self.useFixture(MockPatch('os.kill', side_effect=exception))
+        self.assertFalse(process_exists(123))
+
+    def test_with_unknown_error(self):
+        exception = OSError()
+        exception.errno = errno.ENOMEM
+        self.useFixture(MockPatch('os.kill', side_effect=exception))
+        self.assertRaises(OSError, process_exists, 123)
+
+
+class TestTwoStageKill(TestCase):
+
+    def test_already_dead(self):
+        exception = OSError()
+        exception.errno = errno.ESRCH
+        kill_results = iter([None, exception])
+        kill = self.useFixture(
+            MockPatch('os.kill', side_effect=kill_results)).mock
+        sleep = self.useFixture(MockPatch('time.sleep')).mock
+        two_stage_kill(123)
+        self.assertEqual(2, kill.call_count)
+        kill.assert_has_calls([((123, signal.SIGTERM), {}), ((123, 0), {})])
+        sleep.assert_not_called()
+
+    def test_dies_immediately(self):
+        exception = OSError()
+        exception.errno = errno.ESRCH
+        kill_results = iter([None, None, exception])
+        kill = self.useFixture(
+            MockPatch('os.kill', side_effect=kill_results)).mock
+        sleep = self.useFixture(MockPatch('time.sleep')).mock
+        two_stage_kill(123)
+        self.assertEqual(3, kill.call_count)
+        kill.assert_has_calls(
+            [((123, signal.SIGTERM), {})] + [((123, 0), {})] * 2)
+        sleep.assert_called_once_with(0.1)
+
+    def test_dies_slowly(self):
+        exception = OSError()
+        exception.errno = errno.ESRCH
+        kill_results = iter([None] * 50 + [exception])
+        kill = self.useFixture(
+            MockPatch('os.kill', side_effect=kill_results)).mock
+        sleep = self.useFixture(MockPatch('time.sleep')).mock
+        two_stage_kill(123)
+        self.assertEqual(51, kill.call_count)
+        kill.assert_has_calls(
+            [((123, signal.SIGTERM), {})] + [((123, 0), {})] * 50)
+        self.assertEqual(49, sleep.call_count)
+        sleep.assert_has_calls([((0.1,), {})] * 49)
+
+    def test_requires_sigkill(self):
+        exception = OSError()
+        exception.errno = errno.ESRCH
+        kill_results = iter([None] * 52)
+        kill = self.useFixture(
+            MockPatch('os.kill', side_effect=kill_results)).mock
+        sleep = self.useFixture(MockPatch('time.sleep')).mock
+        two_stage_kill(123)
+        self.assertEqual(52, kill.call_count)
+        kill.assert_has_calls(
+            [((123, signal.SIGTERM), {})] +
+            [((123, 0), {})] * 50 +
+            [((123, signal.SIGKILL), {})])
+        self.assertEqual(50, sleep.call_count)
+        sleep.assert_has_calls([((0.1,), {})] * 50)


### PR DESCRIPTION
The strategy used by two_stage_kill to identify whether the process is
still running wasn't very robust, because in the context of txfixtures
it's typically working with a daemon process which doesn't count as a
child of the calling process, so os.waitpid raises an ECHILD error.  As
a result, we see failures in the Launchpad test suite that result from
TacTestFixture.killTac returning before the daemon has actually finished
exiting.

Nothing in txfixtures cares about the return value of two_stage_kill
anyway, so calling os.waitpid is more effort than we need to go to.
Instead, import some code from Launchpad (by Maris Fogels, Maximiliano
Bertacchini, and me) to detect whether the process is still running
using os.kill(pid, 0) instead, which doesn't require the target process
to be a child of the calling process.