### PR TITLE
Fix tests on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
 
 install:
   - pip install tox-travis

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,10 @@ classifier =
     Operating System :: POSIX
     Programming Language :: Python
     Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Topic :: Software Development :: Quality Assurance
     Topic :: Software Development :: Testing
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -105,7 +105,8 @@ class ServiceProtocolIntegrationTest(TestCase):
         The `ready` deferred fires when the service is ready.
         """
         self.script.sleep(1)
-        self.process = reactor.spawnProcess(self.protocol, self.script.path)
+        self.process = reactor.spawnProcess(
+            self.protocol, self.script.path, [self.script.path])
         yield self.protocol.ready
         self.assertIn("Service process ready", self.logger.output)
 
@@ -118,7 +119,8 @@ class ServiceProtocolIntegrationTest(TestCase):
         self.script.out("hello")
         self.script.sleep(1)
         self.protocol.expectedOutput = "hello"
-        self.process = reactor.spawnProcess(self.protocol, self.script.path)
+        self.process = reactor.spawnProcess(
+            self.protocol, self.script.path, [self.script.path])
         yield self.protocol.ready
         self.assertIn("hello", self.logger.output)
 
@@ -131,7 +133,8 @@ class ServiceProtocolIntegrationTest(TestCase):
         self.script.listen()
         self.script.sleep(1)
         self.protocol.expectedPort = self.script.port
-        self.process = reactor.spawnProcess(self.protocol, self.script.path)
+        self.process = reactor.spawnProcess(
+            self.protocol, self.script.path, [self.script.path])
         yield self.protocol.ready
         sock = socket.socket()
         sock.connect(("localhost", self.script.port))
@@ -148,7 +151,8 @@ class ServiceProtocolIntegrationTest(TestCase):
         self.script.listen()
         self.script.sleep(1)
         self.protocol.expectedPort = self.script.port
-        self.process = reactor.spawnProcess(self.protocol, self.script.path)
+        self.process = reactor.spawnProcess(
+            self.protocol, self.script.path, [self.script.path])
         yield self.protocol.ready
         sock = socket.socket()
         sock.connect(("localhost", self.script.port))
@@ -161,7 +165,8 @@ class ServiceProtocolIntegrationTest(TestCase):
         """If the service doesn't stay up for minUpTime, an error is raised."""
         # Spawn a non-existing process, which will make os.execvp fail,
         # triggering ServiceProtocol.processExited almost immediately.
-        self.process = reactor.spawnProcess(self.protocol, b"/foo/bar")
+        self.process = reactor.spawnProcess(
+            self.protocol, b"/foo/bar", [b"/foo/bar"])
         try:
             yield self.protocol.ready
         except ProcessTerminated as error:
@@ -180,7 +185,8 @@ class ServiceProtocolIntegrationTest(TestCase):
         """
         self.script.sleep(0.2)
         self.protocol.expectedOutput = "hello"
-        self.process = reactor.spawnProcess(self.protocol, self.script.path)
+        self.process = reactor.spawnProcess(
+            self.protocol, self.script.path, [self.script.path])
         try:
             yield self.protocol.ready
         except ProcessDone as error:
@@ -197,7 +203,8 @@ class ServiceProtocolIntegrationTest(TestCase):
         self.script.sleep(1)
         self.protocol.expectedOutput = "hello"
         addTimeout(self.protocol.ready, 0.2, reactor)
-        self.process = reactor.spawnProcess(self.protocol, self.script.path)
+        self.process = reactor.spawnProcess(
+            self.protocol, self.script.path, [self.script.path])
         try:
             yield self.protocol.ready
         except TimeoutError as error:
@@ -222,7 +229,8 @@ class ServiceProtocolIntegrationTest(TestCase):
         _, self.protocol.expectedPort = sock.getsockname()
 
         addTimeout(self.protocol.ready, 0.2, reactor)
-        self.process = reactor.spawnProcess(self.protocol, self.script.path)
+        self.process = reactor.spawnProcess(
+            self.protocol, self.script.path, [self.script.path])
         try:
             yield self.protocol.ready
         except TimeoutError as error:
@@ -240,7 +248,8 @@ class ServiceProtocolIntegrationTest(TestCase):
         """
         self.script.sleep(0.2)
         self.protocol.expectedPort = 9999
-        self.process = reactor.spawnProcess(self.protocol, self.script.path)
+        self.process = reactor.spawnProcess(
+            self.protocol, self.script.path, [self.script.path])
         try:
             yield self.protocol.ready
         except ProcessDone as error:

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py27,py35,doc
+envlist = py27,py35,py36,doc
 skipsdist = True
 
 [tox:travis]
 2.7 = py27
 3.5 = py35,doc
+3.6 = py36
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
After the fix for https://bugs.python.org/issue28732, os.execve (and
hence reactor.spawnProcess) must not be called with an empty argv.