### PR TITLE
Fix syntax error on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 install:
   - pip install tox-travis

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ classifier =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Topic :: Software Development :: Quality Assurance
     Topic :: Software Development :: Testing
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = py27,py35,py36,doc
+envlist = py27,py35,py36,py37,py38,doc
 skipsdist = True
 
 [tox:travis]
 2.7 = py27
 3.5 = py35,doc
 3.6 = py36
+3.7 = py37
+3.8 = py38
 
 [testenv]
 usedevelop = True

--- a/txfixtures/_twisted/testing.py
+++ b/txfixtures/_twisted/testing.py
@@ -15,13 +15,13 @@ EXPECTED_SIGNALS = (signal.SIGTERM, signal.SIGTERM)
 class ThreadedMemoryReactorClock(MemoryReactorClock):
     """Extend Twisted's test reactor with more reactor-level features.
 
-    :ivar async: A flag indicating whether callFromThread calls should be
+    :ivar isAsync: A flag indicating whether callFromThread calls should be
         executed synchronously as soon as callFromThread is called.
     """
 
     def __init__(self):
         super(ThreadedMemoryReactorClock, self).__init__()
-        self.async = False
+        self.isAsync = False
         self.process = MemoryProcess()
         self._internalReaders = set()
 
@@ -35,7 +35,7 @@ class ThreadedMemoryReactorClock(MemoryReactorClock):
         self.running = False
 
     def callFromThread(self, f, *args, **kwargs):
-        if self.async:
+        if self.isAsync:
             return
         f(*args, **kwargs)
 

--- a/txfixtures/tests/test_reactor.py
+++ b/txfixtures/tests/test_reactor.py
@@ -110,7 +110,7 @@ class ReactorTest(TestCase):
         If cleanUp() can't stop the reactor, an error is raised.
         """
         self.fixture.setUp()
-        self.reactor.async = True
+        self.reactor.isAsync = True
         self.fixture.thread.alive = True
 
         error = self.assertRaises(RuntimeError, self.fixture.cleanUp)


### PR DESCRIPTION
txfixtures._twisted.testing used an "async" instance attribute, which is
now a reserved keyword.  Since this module is private, I just renamed
the attribute to "isAsync" rather than doing anything more elaborate.

Fixes #10.