### PR TITLE
Handle newer versions of mongodb

### DIFF
--- a/txfixtures/mongodb.py
+++ b/txfixtures/mongodb.py
@@ -16,7 +16,8 @@ class MongoDB(Service):
         super(MongoDB, self).__init__(
             reactor, command=command, args=args, env=env, timeout=timeout)
 
-        self.expectOutput("waiting for connections on port")
+        self.expectOutput(
+            "waiting for connections on port", "Waiting for connections")
         self.setOutputFormat(FORMAT)
         self.setClientKwargs()
 


### PR DESCRIPTION
mongodb 5.0.6 (and probably earlier versions, but this was what I could
easily test by way of GitHub Actions) produces somewhat different output
to indicate that it's waiting for connections.

This involves extending `Service.expectOutput` to accept multiple
alternatives for the expected output, and hence also changing
`ServiceProtocol.expectedOutput` to be a list rather than a string, so
this should trigger a minor version bump to 0.5.0.