### PR TITLE
Update obsolete tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ skipsdist = True
 usedevelop = True
 install_command = pip install -U {opts} {packages}
 deps = .[test,phantomjs,mongodb]
-whitelist_externals =
+allowlist_externals =
     make
     phantomjs
 setenv =


### PR DESCRIPTION
`whitelist_externals` was replaced by `allowlist_externals`.