### PR TITLE
Assume UTC timezone when parsing loglines

### DIFF
--- a/txfixtures/service.py
+++ b/txfixtures/service.py
@@ -4,7 +4,10 @@ import re
 import signal
 import socket
 
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 from functools import partial
 
 from psutil import Process
@@ -528,6 +531,7 @@ class ServiceOutputParser(LineOnlyReceiver):
                 int(groups["H"]),
                 int(groups["M"]),
                 int(groups["S"]),
+                tzinfo=timezone.utc,
             ).strftime("%s"))
 
         if "msecs" in groups:

--- a/txfixtures/tests/test_service.py
+++ b/txfixtures/tests/test_service.py
@@ -379,7 +379,7 @@ class ServiceOutputParserTest(TestCase):
         self.assertEqual("INFO", record.levelname)
         self.assertEqual("logger", record.name)
         self.assertEqual("hi", record.msg)
-        self.assertEqual(1479113981, record.created)
+        self.assertEqual(1479110381, record.created)
         self.assertEqual(400, record.msecs)
         self.assertEqual("my-app", record.processName)
 


### PR DESCRIPTION
The current parser for the loglines does not take timezones into account.

The only testcase does not show that timezones are present in loglines.

In order to avoid test failures depending on the time of the year, and as logfiles should usually contain UTC times, the UTC timezone is now assumed for parsed dates in loglines.