### PR TITLE
Remove unused code

### DIFF
--- a/txfixtures/tests/test_service.py
+++ b/txfixtures/tests/test_service.py
@@ -379,7 +379,7 @@ class ServiceOutputParserTest(TestCase):
         self.assertEqual("INFO", record.levelname)
         self.assertEqual("logger", record.name)
         self.assertEqual("hi", record.msg)
-        self.assertEqual(1479113981, record.created)
+        self.assertEqual(1479110381, record.created)
         self.assertEqual(400, record.msecs)
         self.assertEqual("my-app", record.processName)
 


### PR DESCRIPTION
Once all remaining tests were fixed, coverage showed a couple of uncovered lines, which were only used by the now removed phantom.js and mongodb fixtures.