### PR TITLE
Restrict maximum supported Twisted version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fixtures
 testtools
-twisted
+twisted<=22.1
 psutil


### PR DESCRIPTION
Twisted versions > 22.1 introduced breaking API changes, so the current code only works with up to version 22.1.

Introducing this change will allow us to modernize CI with a known good state.

After introducing GitHub actions for CI, one of the next steps would be to support both newer versions of Twisted and Python. Python version 3.9 and higher are currently not supported, also due to breaking API changes.